### PR TITLE
Fix incorrect YAML.net nuget path

### DIFF
--- a/PSYaml.psd1
+++ b/PSYaml.psd1
@@ -17,7 +17,7 @@
 ModuleToProcess = 'PSYaml.psm1'
 
 # Version number of this module.
-ModuleVersion = '1.0.0.1'
+ModuleVersion = '1.0.0.2'
 
 # ID used to uniquely identify this module
 GUID = 'b8eb2cda-f09b-4c5d-bf3d-f03d212f0a81'

--- a/PSYaml.psm1
+++ b/PSYaml.psm1
@@ -41,7 +41,7 @@ function Initialize-PsYAML_Module
     #now get the latest version of YAMLdotNet that we have
     $CurrentRelease = Get-ChildItem | where { $_.PSIsContainer } | sort CreationTime -desc | select -f 1
     pop-location
-    Add-Type -Path "$YAMLDotNetLocation\YAMLDotNet\$CurrentRelease\lib\dotnet\yamldotnet.dll"
+    Add-Type -Path "$YAMLDotNetLocation\YAMLDotNet\$CurrentRelease\lib\portable-net45+netcore45+wpa81+wp8+MonoAndroid1+MonoTouch1\yamldotnet.dll"
     
 }
 


### PR DESCRIPTION
# Overview
As per #4 when the module is initialized it looks for the yaml.net assembly in the wrong location.

# Changes
* Update path to load the .net45 assembly. I considered net35, but 45 worked for me so I went with the most recent. Happy to change this if you'd prefer targeting the lowest common denominator.
* Bumped the patch version. Let me know if you'd rather do versioning differently.

Would appreciate your feedback, if you are happy with these changes merging them will help me move forward with using your module. Thanks!