### PR TITLE
Fix issue #13 'Single-element arrays are not preserved'

### DIFF
--- a/PSYaml/Private/ConvertFrom-YAMLDocument.ps1
+++ b/PSYaml/Private/ConvertFrom-YAMLDocument.ps1
@@ -107,6 +107,7 @@ function ConvertFrom-YAMLDocument
         $theNode | ForEach-Object{ 
                                     $TheObject += ConvertFrom-YAMLDocument $_ 
                                  }
+        return ,$TheObject
     }
     else
     {


### PR DESCRIPTION
In Powershell, if a function returns an array of only one element, it gets unwrapped. This is the root cause of issue #13.

This Pull Request fixes it by correctly returning the array.

Simple example:

```powershell
function F($l) { return $l }

$result = F(@("a", "b"))
$result                     # a
                            # b
$result.GetType().Name      # Object[]
$result[0].GetType().Name   # String

$result = F(@("a"))
$result                     # a
$result.GetType().Name      # String (Ouch!)

$result = F(@())
$result                     #
$result.GetType().Name      # ERROR! You cannot call a method on a null-valued expression.
```
```powershell
function Better-F($l) { return ,$l }

$result = Better-F(@("a", "b"))
$result                     # a
                            # b
$result.GetType().Name      # Object[]
$result[0].GetType().Name   # String

$result = Better-F(@("a"))
$result                     # a
$result.GetType().Name      # Object[] (FIXED!)
$result[0].GetType().Name   # String

$result = Better-F(@())
$result                     #
$result.GetType().Name      # Object[]
```