### PR TITLE
fix typo in first example

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ Please note that the **Master** branch has the latest, ready-for-production vers
 ## Example Usage
 ```PowerShell
 import-module psyaml
-$yaml = @"
+$yamlString = @"
 anArray:
 - 1
 - 2


### PR DESCRIPTION
First, just want to say I love your work!
Second, the example will return "ConvertFrom-Yaml : Cannot bind argument to parameter 'YamlString' because it is null." unless this typo is fixed.