### PR TITLE
Fix installation guides

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,22 +52,34 @@ Author: Phil-Factor (philipFactor@gmail.com)
 |  1.0.1    | Converted single psm1 file to multiple public/private functions   |
 
 ## Installation
-### One time setup
-* Download/clone the repository
-* Copy the PSYaml folder to a module path (e.g. `$env:USERPROFILE\Documents\WindowsPowerShell\Modules\`)
-* Alternatively, in the PS-PSYaml folder use PSDeploy (`Invoke-PSDeploy -Path .\PSDeploy\`)
+### Setup
 
+* Install and import PSDeploy module.
+
+```powershell
+# Install / Import PSDeploy
+Install-Module PSDeploy
+Import-Module PSDeplooy
+# Run PSDeploy
+PSDeploy <path_to_PSDeploy_folder>\PSYaml.PSDeploy.ps1
+# Import PSYaml
+Import-Module <path_to_PSYaml_folder>\PSYaml.psm1
+```
 ### Automated Install
-* Assuming you have PowerShell v5 and a Nuget Repository configured, use the built in Module management (`Install-Module PSYaml`)
-
-## Import the module.
-`Import-Module PSYaml    #Alternatively, Import-Module \\Path\To\PSYaml`
+* Assuming you have PowerShell v5 and a Nuget Repository configured, use the built in Module management
+```powershell
+Install-Module FXPSYaml -Force
+Import-Module FXPSYaml
+```
 
 ## Get commands in the module
-`Get-Command -Module PSYaml`
-
+```powershell
+Get-Command -Module PSYaml
+```
 ## Get help
-`Get-Help ConvertFrom-Yaml -Full`
-`Get-Help about_PSYaml`
+```powershell
+Get-Help ConvertFrom-Yaml -Full
+Get-Help about_PSYaml
+```
 
 

--- a/README.md
+++ b/README.md
@@ -60,8 +60,10 @@ Author: Phil-Factor (philipFactor@gmail.com)
 # Install / Import PSDeploy
 Install-Module PSDeploy
 Import-Module PSDeplooy
+
 # Run PSDeploy
 PSDeploy <path_to_PSDeploy_folder>\PSYaml.PSDeploy.ps1
+
 # Import PSYaml
 Import-Module <path_to_PSYaml_folder>\PSYaml.psm1
 ```
@@ -81,5 +83,3 @@ Get-Command -Module PSYaml
 Get-Help ConvertFrom-Yaml -Full
 Get-Help about_PSYaml
 ```
-
-

--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ nested:
 key: value
 "@
 
-$YamlObject = ConvertFrom-YAML $yamlString
+$yamlString | ConvertFrom-YAML
 
 # Converting from a Powershell hashtable to Yaml.
 $hashtable = @{anArray = 1, 2, 3; nested = @{array = 1, 2, 3}; key = "value"}

--- a/README.md
+++ b/README.md
@@ -62,14 +62,18 @@ Author: Phil-Factor (philipFactor@gmail.com)
 
 # Installation
 ### PSGallery Install
-* Assuming you have PowerShell v5 and a Nuget Repository configured, use the built in Module management
+`Requires Powershell V5`
 ```powershell
+# [Optional] Ensure PowershellGet package provider is up to date
+# Install-Module -Name PowerShellGet -Repository PSGallery -Force
+
+# Install and Import module from PSGallery
 Install-Module FXPSYaml -Force
 Import-Module FXPSYaml
 ```
 ### Local Install
 ```powershell
-# Install / Import PSDeploy
+# Install / Import PSDeploy module first
 Install-Module PSDeploy
 Import-Module PSDeploy
 
@@ -84,7 +88,8 @@ Import-Module <path_to_PSYaml_folder>\PSYaml.psm1
 Get-Command -Module PSYaml
 ```
 # Get help
+> Use PSYaml instead FXPSYaml if you have installed it using Local install method
 ```powershell
-Get-Help ConvertFrom-Yaml -Full
-Get-Help about_PSYaml
+# Get full help of all module commands
+get-command -Module FXPSYaml | select -ExpandProperty name | ForEach-Object {write-host "$_" -BackgroundColor "red"; Get-Help $_}
 ```

--- a/README.md
+++ b/README.md
@@ -91,5 +91,5 @@ Get-Command -Module PSYaml
 > Use PSYaml instead FXPSYaml if you have installed it using Local install method
 ```powershell
 # Get full help of all module commands
-get-command -Module FXPSYaml | select -ExpandProperty name | ForEach-Object {write-host "$_" -BackgroundColor "red"; Get-Help $_}
+get-command -Module FXPSYaml | select -ExpandProperty name | ForEach-Object {write-host "$_" -BackgroundColor "red"; Get-Help $_ -full}
 ```

--- a/README.md
+++ b/README.md
@@ -59,13 +59,10 @@ Install-Module FXPSYaml -Force
 Import-Module FXPSYaml
 ```
 ### Local Install
-
-* Install and import PSDeploy module.
-
 ```powershell
 # Install / Import PSDeploy
 Install-Module PSDeploy
-Import-Module PSDeplooy
+Import-Module PSDeploy
 
 # Run PSDeploy
 PSDeploy <path_to_PSDeploy_folder>\PSYaml.PSDeploy.ps1
@@ -73,7 +70,6 @@ PSDeploy <path_to_PSDeploy_folder>\PSYaml.PSDeploy.ps1
 # Import PSYaml
 Import-Module <path_to_PSYaml_folder>\PSYaml.psm1
 ```
-
 ## Get commands in the module
 ```powershell
 Get-Command -Module PSYaml

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # PSYaml
 
-## Build Status
+# Build Status
 
 |Branch | Status |
 |-------|:--------:|
@@ -8,22 +8,27 @@
 
 <img src=".\Media\YAML_PS.png" height="200" align="right" />
 
-## Introduction
+# Introduction
 This module will help users convert from/to YAML. For more information see [the documentation](./Documentation.md) or the [legacy documentation](./Legacy_Documentation.adoc).
 
 Please note that the **Master** branch has the latest, ready-for-production version. The **release/stage** branch is the holding ground for master merges where integration testing will take place. Other branches with active development will be denoted by having a prefix ( **feature/**, **bugfix/**, **release/**, etc) followed by an unique identifier. Nothing is merged into **release/stage** branch without code review, and only code that passes testing in the **release/stage** branch will be merged into **master**.
 
-## Features
+# Features
 * Fancy Logo
 * Bundled binary
 * Pester Testing
 
-## ToDo
+# ToDo
 * Clean up documentation
 
 ## Example Usage
 ```PowerShell
-import-module psyaml
+
+# Ensure module is imported in the current Powershell session
+# Import-Module FXPSYaml (PSGallery) - Use it if you have installed from PSGallery.
+# Import-Module <path_to_PSYaml_folder>\PSYaml.psm1 (local) - Use it if you have installed it locally.
+
+# Converting from yaml to Powershell
 $yamlString = @"
 anArray:
 - 1
@@ -35,10 +40,14 @@ nested:
   - is
   - an
   - array
-hello: world
+key: value
 "@
+
 $YamlObject = ConvertFrom-YAML $yamlString
-ConvertTo-YAML $YamlObject
+
+# Converting from a Powershell hashtable to Yaml.
+$hashtable = @{anArray = 1, 2, 3; nested = @{array = 1, 2, 3}; key = "value"}
+$hashtable | ConvertTo-Yaml
 ```
 
 ## Contact Information
@@ -51,7 +60,7 @@ Author: Phil-Factor (philipFactor@gmail.com)
 |  1.0.2    | Reformated several sections for readability, added pester tests   |
 |  1.0.1    | Converted single psm1 file to multiple public/private functions   |
 
-## Installation
+# Installation
 ### PSGallery Install
 * Assuming you have PowerShell v5 and a Nuget Repository configured, use the built in Module management
 ```powershell
@@ -70,11 +79,11 @@ PSDeploy <path_to_PSDeploy_folder>\PSYaml.PSDeploy.ps1
 # Import PSYaml
 Import-Module <path_to_PSYaml_folder>\PSYaml.psm1
 ```
-## Get commands in the module
+# List module commands
 ```powershell
 Get-Command -Module PSYaml
 ```
-## Get help
+# Get help
 ```powershell
 Get-Help ConvertFrom-Yaml -Full
 Get-Help about_PSYaml

--- a/README.md
+++ b/README.md
@@ -52,7 +52,13 @@ Author: Phil-Factor (philipFactor@gmail.com)
 |  1.0.1    | Converted single psm1 file to multiple public/private functions   |
 
 ## Installation
-### Setup
+### PSGallery Install
+* Assuming you have PowerShell v5 and a Nuget Repository configured, use the built in Module management
+```powershell
+Install-Module FXPSYaml -Force
+Import-Module FXPSYaml
+```
+### Local Install
 
 * Install and import PSDeploy module.
 
@@ -66,12 +72,6 @@ PSDeploy <path_to_PSDeploy_folder>\PSYaml.PSDeploy.ps1
 
 # Import PSYaml
 Import-Module <path_to_PSYaml_folder>\PSYaml.psm1
-```
-### Automated Install
-* Assuming you have PowerShell v5 and a Nuget Repository configured, use the built in Module management
-```powershell
-Install-Module FXPSYaml -Force
-Import-Module FXPSYaml
 ```
 
 ## Get commands in the module


### PR DESCRIPTION
Hi.

I needed this to verify if I had issues with a YAML file at work, so I realize a quick way to check that would be seeing if this could deserialize in Powershell.

The module has worked for my purposes so I'm glad about it, but during installation it was quite troublesome than usually it is when installing Powershell modules, the current guides are misleading.

1. By downloading the module and placing it under $home\documents\WindowsPowershell\Modules folder, when importing the module it does not work and it throws an error.

2. By running import-module targeting PSYaml.psm1, it does import but the commands don't work because it will miss assembly dependencies.

3. Installing module from PSGallery using Install-Module PSYaml is not possible because module is not found.